### PR TITLE
Add test for initialization issue.

### DIFF
--- a/bayes_kit/hmc.py
+++ b/bayes_kit/hmc.py
@@ -23,7 +23,11 @@ class HMCDiag:
         self._steps = steps
         self._metric = metric_diag or np.ones(self._dim)
         self._rng = np.random.default_rng(seed)
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
 
     def __iter__(self) -> Iterator[Draw]:
         return self

--- a/bayes_kit/mala.py
+++ b/bayes_kit/mala.py
@@ -25,7 +25,11 @@ class MALA:
         self._epsilon = epsilon
         self._dim = self._model.dims()
         self._rng = np.random.default_rng(seed)
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
         self._log_p_theta, logpgrad = self._model.log_density_gradient(self._theta)
         self._log_p_grad_theta = np.asanyarray(logpgrad)
 

--- a/bayes_kit/metropolis.py
+++ b/bayes_kit/metropolis.py
@@ -94,7 +94,11 @@ class MetropolisHastings:
         self._rng = np.random.default_rng(seed)
         self._proposal_fn = proposal_fn
         self._transition_lp_fn = transition_lp_fn
-        self._theta = init if init is not None else self._rng.normal(size=self._dim)
+        self._theta = (
+            init
+            if (init is not None and init.shape != (0,))
+            else self._rng.normal(size=self._dim)
+        )
         self._log_p_theta = self._model.log_density(self._theta)
 
     def __iter__(self) -> Iterator[Draw]:

--- a/test/test_theta_initialization.py
+++ b/test/test_theta_initialization.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy.typing import NDArray
+from unittest.mock import Mock
+
+from bayes_kit.hmc import HMCDiag
+from bayes_kit.mala import MALA
+from bayes_kit.metropolis import Metropolis, MetropolisHastings
+from bayes_kit.model_types import HessianModel
+
+
+def assert_not_empty_array(a: NDArray[np.float64]):
+    with np.testing.assert_raises(AssertionError):
+        np.testing.assert_array_equal(a, np.array([]))
+
+
+def make_models(init: NDArray[np.float64], dims: int = 1):
+    # For the purposes of this (and future) tests, we only care about the model's dimensions.
+    mock_model: HessianModel = Mock()
+    mock_model.dims = Mock(return_value=dims)
+    mock_model.log_density_gradient = Mock(return_value=(0.5, (0,)))
+    mock_model.log_density_hessian = Mock(return_value=(0, 5, (0,), (0,)))
+
+    # TODO: Add ensemble/stretcher once the class is available
+    hmc = HMCDiag(mock_model, stepsize=0.25, steps=10, init=init)
+    mala = MALA(mock_model, epsilon=0.5, init=init)
+    metro = Metropolis(mock_model, lambda x: 1, init=init)
+    mh = MetropolisHastings(mock_model, lambda x: 1, lambda x, y: 1, init=init)
+    # TemperedLikelihoodSMC omitted since it does not have explicit-value initialization of thetas
+
+    return [hmc, mala, metro, mh]
+
+
+def test_init_with_empty_numpy_array() -> None:
+    # an "empty" initialization should be treated as no initialization
+    # (i.e. not honored)
+    init = np.array([])
+    models = make_models(init)
+    for model in models:
+        assert_not_empty_array(model._theta)
+
+
+def test_init_with_one_element_numpy_array() -> None:
+    init = np.array([3])
+    models = make_models(init)
+    for model in models:
+        np.testing.assert_array_equal(model._theta, init)
+
+
+def test_init_with_multi_element_numpy_array() -> None:
+    init = np.array([3, 3, 3])
+    models = make_models(init, dims=3)
+    for model in models:
+        np.testing.assert_array_equal(model._theta, init)


### PR DESCRIPTION
In order to preserve the existing behavior (of using a random draw if an empty array is passed), I added a check for an empty `init` array. I expect this will go away shortly when we implement shape checking for parameter initialization values, but I didn't want to complicate or hold up your PR further just for that.

Confirmed that these tests pass with this code, and that the 3rd test (init worked with multi-element numpy array) fails on upstream main.